### PR TITLE
Setup sudoers to: target ALL hosts, NOPASSWD

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,14 +10,14 @@
 source .envrc
 
 # give the user permission to change LED trigger
-echo "$USER cms051=/usr/bin/tee /sys/class/leds/*/trigger" | sudo tee -a /etc/sudoers
+echo "$USER ALL=(root) NOPASSWD: /usr/bin/tee /sys/class/leds/*/trigger" | sudo tee -a /etc/sudoers
 # give the user permission to mount the card
-sudo echo "$USER cms051=/bin/mount ${CARD_DEV} ${CARD_MOUNT_POINT}" | sudo tee -a /etc/sudoers
+sudo echo "$USER ALL=(root) NOPASSWD: /bin/mount ${CARD_DEV} ${CARD_MOUNT_POINT}" | sudo tee -a /etc/sudoers
 sudo mkdir -p ${CARD_MOUNT_POINT}
 # give the user permission to set led blink delay
-echo "$USER cms051=/usr/bin/tee /sys/class/leds/*/delay_on" | sudo tee -a /etc/sudoers
+echo "$USER ALL=(root) NOPASSWD: /usr/bin/tee /sys/class/leds/*/delay_on" | sudo tee -a /etc/sudoers
 # give the user permission to unmount
-sudo echo "$USER cms051=/bin/umount ${CARD_MOUNT_POINT}" | sudo tee -a /etc/sudoers
+sudo echo "$USER ALL=(root) NOPASSWD: /bin/umount ${CARD_MOUNT_POINT}" | sudo tee -a /etc/sudoers
 
 mkdir -p ~/.config/systemd/user
 ln -s `pwd`*service ~/.config/systemd/user


### PR DESCRIPTION
There was a very bogus copy/pasted host being used in granting permissions.
Also add NOPASSWD so this can automatically happen!

Supposedly the user has full sudoers access NOPASSWD already so this isn't crucial but whoa boy that's gut wrenchingly bad to see.